### PR TITLE
Removing broken root-conda Docker references

### DIFF
--- a/_episodes/07-adding-ci-to-your-code.md
+++ b/_episodes/07-adding-ci-to-your-code.md
@@ -110,7 +110,7 @@ Authenticating with credentials from job payload (GitLab Registry)
 > Don't panic. You do not need to understand docker to be able to use it.
 {: .callout}
 
-Let's go ahead and update our `.gitlab-ci.yml` and fix it to use a versioned docker image that has `root`: `rootproject/root:6.26.10-conda` from the [rootproject/root-conda](https://hub.docker.com/r/rootproject/root-conda) docker hub page.
+Let's go ahead and update our `.gitlab-ci.yml` and fix it to use a versioned docker image that has `root`: `rootproject/root:6.26.10-conda` from the [rootproject/root](https://hub.docker.com/r/rootproject/root) docker hub page.
 
 > ## Still failed??? What the hell.
 >
@@ -136,7 +136,7 @@ Ok, let's go ahead and update our `.gitlab-ci.yml` again, and it better be fixed
 
 # Building multiple versions
 
-Great, so we finally got it working... CI/CD isn't obviously powerful when you're only building one thing. Let's build both the version of the code we're testing and also test that the latest ROOT image (`rootproject/root-conda:latest`) works with our code. Call this new job `build_skim_latest`.
+Great, so we finally got it working... CI/CD isn't obviously powerful when you're only building one thing. Let's build both the version of the code we're testing and also test that the latest ROOT image (`rootproject/root:latest`) works with our code. Call this new job `build_skim_latest`.
 
 > ## Adding the `build_skim_latest` job
 >
@@ -156,7 +156,7 @@ Great, so we finally got it working... CI/CD isn't obviously powerful when you'r
 > >    - $COMPILER -g -O3 -Wall -Wextra -Wpedantic -o skim skim.cxx $FLAGS
 > >
 > > build_skim_latest:
-> >   image: rootproject/root-conda:latest
+> >   image: rootproject/root:latest
 > >   script:
 > >    - COMPILER=$(root-config --cxx)
 > >    - FLAGS=$(root-config --cflags --libs)

--- a/_episodes/08-eins-zwei-dry.md
+++ b/_episodes/08-eins-zwei-dry.md
@@ -57,7 +57,7 @@ build_skim:
    - $COMPILER -g -O3 -Wall -Wextra -Wpedantic -o skim skim.cxx $FLAGS
 
 build_skim_latest:
-  image: rootproject/root-conda:latest
+  image: rootproject/root:latest
   before_script:
    - COMPILER=$(root-config --cxx)
    - FLAGS=$(root-config --cflags --libs)
@@ -95,7 +95,7 @@ We've already started to repeat ourselves. How can we combine the two into a sin
 > >    - $COMPILER -g -O3 -Wall -Wextra -Wpedantic -o skim skim.cxx $FLAGS
 > >
 > > build_skim_latest:
-> >   image: rootproject/root-conda:latest
+> >   image: rootproject/root:latest
 > >   before_script:
 > >    - COMPILER=$(root-config --cxx)
 > >    - FLAGS=$(root-config --cflags --libs)
@@ -171,7 +171,7 @@ Note how `.in-docker` overrides `:rspec:tags` because it's "closest in scope".
 > >
 > > build_skim_latest:
 > >   extends: .build_template
-> >   image: rootproject/root-conda:latest
+> >   image: rootproject/root:latest
 > >   allow_failure: yes
 > > ~~~
 > > {: .language-yaml}

--- a/_episodes/10-the-worlds-a-stage.md
+++ b/_episodes/10-the-worlds-a-stage.md
@@ -34,7 +34,7 @@ build_skim:
 
 build_skim_latest:
   extends: .build_template
-  image: rootproject/root-conda:latest
+  image: rootproject/root:latest
   allow_failure: yes
 ~~~
 {: .language-yaml}
@@ -92,7 +92,7 @@ Stages allow us to categorize jobs by functionality, such as `build`, or `test`,
 > >
 > > build_skim_latest:
 > >   extends: .build_template
-> >   image: rootproject/root-conda:latest
+> >   image: rootproject/root:latest
 > >   allow_failure: yes
 > > ~~~
 > > {: .language-yaml}

--- a/_episodes/11-skim-milk.md
+++ b/_episodes/11-skim-milk.md
@@ -41,7 +41,7 @@ build_skim:
 
 build_skim_latest:
   extends: .build_template
-  image: rootproject/root-conda:latest
+  image: rootproject/root:latest
   allow_failure: yes
 ~~~
 {: .language-yaml}

--- a/_episodes/13-plotting-to-take-over-the-world.md
+++ b/_episodes/13-plotting-to-take-over-the-world.md
@@ -52,7 +52,7 @@ build_skim:
 
 build_skim_latest:
   extends: .build_template
-  image: rootproject/root-conda:latest
+  image: rootproject/root:latest
   allow_failure: yes
 
 skim_ggH:

--- a/_episodes/14-a-simple-test.md
+++ b/_episodes/14-a-simple-test.md
@@ -40,7 +40,7 @@ build_skim:
 
 build_skim_latest:
   extends: .build_template
-  image: rootproject/root-conda:latest
+  image: rootproject/root:latest
   allow_failure: yes
 
 skim_ggH:

--- a/_episodes/15-homework.md
+++ b/_episodes/15-homework.md
@@ -38,7 +38,7 @@ build_skim:
 
 build_skim_latest:
   extends: .build_template
-  image: rootproject/root-conda:latest
+  image: rootproject/root:latest
   allow_failure: yes
 
 skim_ggH:


### PR DESCRIPTION
`rootproject/root-conda` is not available anymore. Replacing build_skim_latest tests with `root:latest`.