### PR TITLE
expand lesson coverage, update some existing sections

### DIFF
--- a/.codespell-ignore-lines
+++ b/.codespell-ignore-lines
@@ -1,0 +1,1 @@
+git stauts

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+exclude-file = .codespell-ignore-lines

--- a/README.md
+++ b/README.md
@@ -19,13 +19,6 @@ This repository generates the corresponding lesson website from [The Carpentries
 
 The aim of this module is to explore what it means to build a CI/CD workflow and expand on concepts unique to GitLab’s CI/CD.
 
-## Past events and videos
-
-* [June 2020](https://indico.cern.ch/event/904759/)
-* [Feb 2020](https://indico.cern.ch/event/854880/)
-
-Emoji key: 🎥 (full video recordings availabile), ⛏️ (hackathon)
-
 ## Contributing
 <!-- CENTRALLY MAINTAINED SECTION -->
 <!-- Remove the above marker to disable having this section be overwritten -->

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
+# HSF Training CI/CD - GitLab Edition
 [![HSF Training Center][training-center-badge]][hsf-training-center]
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 [![Upcoming Events][schools-badge]][schools]
-[![Twitter Follow][twitter-badge]][twitter]
+<!--[![Twitter Follow][twitter-badge]][twitter]
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
@@ -11,21 +12,21 @@
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/hsf-training/hsf-training-cicd/gh-pages.svg)](https://results.pre-commit.ci/latest/github/hsf-training/hsf-training-cicd/gh-pages)
 [![pages-build-deployment](https://github.com/hsf-training/hsf-training-cicd/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/hsf-training/hsf-training-cicd/actions/workflows/pages/pages-build-deployment)
 
-# HSF Training CI/CD -- GitLab Edition
+This repository generates the corresponding lesson website from [The Carpentries](https://carpentries.org/) repertoire of lessons.
 
 > **Note**
 > Click [here](https://hsf-training.github.io/hsf-training-cicd/) for the training website!
 
 The aim of this module is to explore what it means to build a CI/CD workflow and expand on concepts unique to GitLab’s CI/CD.
 
-## 📅 Past events and videos
+## Past events and videos
 
 * [June 2020](https://indico.cern.ch/event/904759/)
 * [Feb 2020](https://indico.cern.ch/event/854880/)
 
 Emoji key: 🎥 (full video recordings availabile), ⛏️ (hackathon)
 
-## 🤗 Contributing
+## Contributing
 <!-- CENTRALLY MAINTAINED SECTION -->
 <!-- Remove the above marker to disable having this section be overwritten -->
 
@@ -63,7 +64,7 @@ by Scott Chacon.
 Look for the tag [![good_first_issue]][gfi-badge], which marks particularly simple issues to get you started.
 
 <!-- END CENTRALLY MAINTAINED SECTION -->
-## 💖 Authors
+## Authors
 
 This lesson was written by
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HSF Training CI/CD - GitLab Edition
+# Continuous Integration and Deployment (CI/CD) with GitLab
 [![HSF Training Center][training-center-badge]][hsf-training-center]
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors-)

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ the content of the lesson:
 Even more people contributed to the framework, but they are too many to list!
 Instead, all regular contributors are listed on our [HSF Training Community page][hsf-training-community].
 
+## Citation
+
+To cite this lesson, please consult with [CITATION](CITATION)
+
 ## Open Educational Resources (OER) on Zenodo
 
 This lesson is included in the ETH Domain Open Educational Resources for Research Data Management (RDM) community on Zenodo. These resources support researchers, students, and RDM staff in implementing best practices across the research data lifecycle. The materials developed here are published under open licenses (CC BY 4.0) and can be freely reused and adapted for teaching and training initiatives worldwide.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ the content of the lesson:
 Even more people contributed to the framework, but they are too many to list!
 Instead, all regular contributors are listed on our [HSF Training Community page][hsf-training-community].
 
+## Open Educational Resources (OER) on Zenodo
+
+This lesson is included in the ETH Domain Open Educational Resources for Research Data Management (RDM) community on Zenodo. These resources support researchers, students, and RDM staff in implementing best practices across the research data lifecycle. The materials developed here are published under open licenses (CC BY 4.0) and can be freely reused and adapted for teaching and training initiatives worldwide.
+
 
 [lesson-example]: https://carpentries.github.io/lesson-example
 [pre-commit]: https://pre-commit.com/

--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ baseurl: /hsf-training-cicd
 carpentry: "hsf"
 
 # Overall title for pages.
-title: "Continuous Integration / Continuous Development (CI/CD)"
+title: "Continuous Integration / Continuous Deployment (CI/CD)"
 
 # Life cycle stage of the lesson
 # possible values: "pre-alpha", "alpha", "beta", "stable"

--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ baseurl: /hsf-training-cicd
 carpentry: "hsf"
 
 # Overall title for pages.
-title: "Continuous Integration / Continuous Deployment (CI/CD)"
+title: "Continuous Integration / Continuous Deployment (CI/CD) with GitLab"
 
 # Life cycle stage of the lesson
 # possible values: "pre-alpha", "alpha", "beta", "stable"

--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -5,12 +5,12 @@ exercises: 0
 questions:
 - What is continuous integration / continuous deployment?
 objectives:
-- Understand why CI/CD is important
-- Learn what can be possible with CI/CD
-- Find resources to explore in more depthg
+- Understand why CI/CD is important.
+- Learn what is possible with CI/CD.
+- Find resources to explore in more depth.
 keypoints:
-- CI/CD is crucial for any reproducibility and testing
-- Take advantage of automation to reduce your workload
+- CI/CD is crucial for any reproducibility and testing.
+- Take advantage of automation to reduce your workload.
 ---
 <iframe width="560" height="315" src="https://www.youtube.com/embed/6gQTE2djdr4?si=PSlNzYPdkwZc1bot" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
@@ -26,7 +26,7 @@ Continuous Integration (CI) is the concept of literal continuous integration of 
 
 ## Breaking Changes
 
-What does it even mean to "break" something? The idea of "breaking" something is pretty contextual. If you're working on C++ code, then you probably want to make sure things compile and run without segfaulting at the bare minimum. If it's python code, maybe you have some tests with `pytest` that you want to make sure pass ("exit successfully"). Or if you're working on a paper draft, you might check for grammar, misspellings, and that the document compiles from LaTeX. Whatever the use-case is, integration is about **catching** breaking changes.
+What does it even mean to "break" something? The idea of "breaking" something is pretty contextual. If you're working on C++ code, then you probably want to make sure things compile and run without segfaulting at the bare minimum. If it's Python code, maybe you have some tests with `pytest` that you want to make sure pass ("exit successfully"). Or if you're working on a paper draft, you might check for grammar, misspellings, and that the document compiles from LaTeX. Whatever the use-case is, integration is about **catching** breaking changes.
 
 > ## Don't know `pytest` ?
 > To learn more about `pytest` visit [its documentation](https://pytest.org/) or follow [this training module](http://carpentries-incubator.github.io/python-testing/).
@@ -35,7 +35,7 @@ What does it even mean to "break" something? The idea of "breaking" something is
 
 ## Deployment
 
-Similarly, "deployment" can mean a lot of things. Perhaps you have a Curriculum Vitae (CV) that is automatically built from LaTeX and uploaded to your website. Another case is to release docker images of your framework that others depend on. Maybe it's just uploading documentation. Or to even upload a new tag of your python package on `pypi`. Whatever the use-case is, deployment is about **releasing** changes.
+Similarly, "deployment" can mean a lot of things. Perhaps you have a Curriculum Vitae (CV) that is automatically built from LaTeX and uploaded to your website. Another case is to release Docker images of your framework that others depend on. Maybe it's just uploading documentation. Or to even upload a new tag of your Python package on `pypi`. Whatever the use-case is, deployment is about **releasing** changes.
 
 ## Workflow Automation
 
@@ -47,7 +47,7 @@ CI/CD is the first step to automating your entire workflow. Imagine everything y
 > Any command you run on your computer can be equivalently run in a CI job.
 {: .callout}
 
-Don't just limit yourself to thinking of CI/CD as primarily for testing changes, but as one part of automating an entire development cycle. You can trigger notifications to your cellphone, fetch/download new data, execute cron jobs, and so much more. However, for the lessons you'll be going through today and that you've just recently learned about python testing with `pytest`, we'll focus primarily on setting up CI/CD with tests for code that you've written already.
+Don't just limit yourself to thinking of CI/CD as primarily for testing changes, but as one part of automating an entire development cycle. You can trigger notifications to your cellphone, fetch/download new data, execute cron jobs, and so much more. However, for the lessons you'll be going through today and that you've just recently learned about Python testing with `pytest`, we'll focus primarily on setting up CI/CD with tests for code that you've written already.
 
 # CI/CD Solutions
 

--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -47,7 +47,7 @@ CI/CD is the first step to automating your entire workflow. Imagine everything y
 > Any command you run on your computer can be equivalently run in a CI job.
 {: .callout}
 
-Don't just limit yourself to thinking of CI/CD as primarily for testing changes, but as one part of automating an entire development cycle. You can trigger notifications to your cellphone, fetch/download new data, execute cron jobs, and so much more. However, for the lessons you'll be going through today and that you've just recently learned about Python testing with `pytest`, we'll focus primarily on setting up CI/CD with tests for code that you've written already.
+Don't just limit yourself to thinking of CI/CD as primarily for testing changes, but as one part of automating an entire development cycle. You can trigger notifications to your cellphone, fetch/download new data, execute cron jobs, and so much more. However, for this lesson, we'll focus primarily on setting up CI/CD with tests for existing code.
 
 # CI/CD Solutions
 
@@ -63,7 +63,7 @@ Now, obviously, we're not going to make our own fully-fledged CI/CD solution. Pl
 - [Buddy](https://buddy.works/)
 - [CodeFresh](https://g.codefresh.io/)
 
-For today's lesson, we'll only focus on GitLab's solution. However, be aware that all the concepts you'll be taught today: including pipelines, stages, jobs, artifacts; all exist in other solutions by similar/different names. For example, GitLab supports two features known as caching and artifacts; but Travis doesn't quite implement the same thing for caching and has no native support for artifacts. Therefore, while we don't discourage you from trying out other solutions, there's no "one size fits all" when designing your own CI/CD workflow.
+For this lesson, we'll only focus on GitLab's solution. However, be aware that all the concepts you'll be taught today: including pipelines, stages, jobs, artifacts; all exist in other solutions by similar/different names. For example, GitLab supports two features known as caching and artifacts; but Travis doesn't quite implement the same thing for caching and has no native support for artifacts. Therefore, while we don't discourage you from trying out other solutions, there's no "one size fits all" when designing your own CI/CD workflow.
 
 > ## Parallel lesson on GitHub CI/CD
 > We also have a [training on GitHub actions, the CI/CD system of GitHub](https://hsf-training.github.io/hsf-training-cicd-github/)

--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -16,7 +16,20 @@ keypoints:
 
 # What is CI/CD?
 
-Continuous Integration (CI) is the concept of literal continuous integration of code changes. That is, every time a contributor (student, colleague, random bystander) provides new changes to your codebase, those changes are tested to make sure they don't "break" anything. Continuous Deployment (CD), similarly, is the literal continuous deployment of code changes. That means that, assuming the CI passes, you'd like to automatically deploy those changes.
+Continuous Integration ([CI](en.wikipedia.org/wiki/Continuous_integration)), and Continuous Deployment ([CD](https://en.wikipedia.org/wiki/Continuous_deployment)) are two related concepts in the field of [DevOps](https://en.wikipedia.org/wiki/DevOps), a sub-domain of software engineering.
+
+
+<dl>
+  <dt>CI</dt>
+  <dd>Continuously integrates source code changes into your repository while testing to ensure the changes do not "break" anything.</dd>
+  <dt>CD</dt>
+  <dd>Continuously deploys a service based on your code.</dd>
+</dl>
+
+A common example of a CI/CD workflow or pipeline in a repository would be one which&mdash;after each push of a set of commits&mdash;tests the codebase (via CI) and deploys documentation (via CD) on a website.
+
+CI/CD workflows can be configured to run after a push, after a merge-request, or on a schedule. The broader puprose of CI/CD is to automate anything repetitive that doesn't need to be done manually, and can be thought of a labour-based manifestation of the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) (don't repeat yourself) principle in programming.
+
 
 > ## Catch and Release
 >

--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -61,7 +61,6 @@ Now, obviously, we're not going to make our own fully-fledged CI/CD solution. Pl
 - [Bamboo](https://www.atlassian.com/software/bamboo)
 - [Jenkins](https://jenkins.io/)
 - [Buddy](https://buddy.works/)
-- [CodeShip](https://codeship.com/)
 - [CodeFresh](https://g.codefresh.io/)
 
 For today's lesson, we'll only focus on GitLab's solution. However, be aware that all the concepts you'll be taught today: including pipelines, stages, jobs, artifacts; all exist in other solutions by similar/different names. For example, GitLab supports two features known as caching and artifacts; but Travis doesn't quite implement the same thing for caching and has no native support for artifacts. Therefore, while we don't discourage you from trying out other solutions, there's no "one size fits all" when designing your own CI/CD workflow.

--- a/_episodes/02-enter-sandman.md
+++ b/_episodes/02-enter-sandman.md
@@ -3,17 +3,17 @@ title: "Exit Codes"
 teaching: 10
 exercises: 10
 objectives:
-  - Understand exit codes
-  - How to print exit codes
-  - How to set exit codes in a script
-  - How to ignore exit codes
-  - Create a script that terminates in success/error
+  - Understand exit codes.
+  - Learn how to print exit codes.
+  - Learn how to set exit codes in a script.
+  - Learn how to ignore exit codes.
+  - Create a script that terminates in success/error.
 questions:
   - What is an exit code?
 hidden: false
 keypoints:
-  - Exit codes are used to identify if a command or script executed with errors or not
-  - Not everyone respects exit codes
+  - Exit codes are used to identify if a command or script executed with errors or not.
+  - Not everyone respects exit codes.
 
 ---
 
@@ -91,7 +91,7 @@ Try out some other commands on your system, and see what things look like.
 
 # Printing Exit Codes
 
-As you've seen above, the exit code from the last executed command is stored in the `$?` environment variable. Accessing from a shell is easy `echo $?`. What about from python? There are many different ways depending on which library you use. Using similar examples above, we can use the (note: deprecated) `os.system` call:
+As you've seen above, the exit code from the last executed command is stored in the `$?` environment variable. Accessing from a shell is easy `echo $?`. What about from Python? There are many different ways depending on which library you use. Using similar examples above, we can use the (note: deprecated) `os.system` call:
 
 > ## Snake Charming
 >
@@ -161,7 +161,7 @@ To finish up this section, one thing you'll notice sometimes (in ATLAS or CMS) i
 ~~~
 {: .language-bash}
 
-The `command_1 || command_2` operator means to execute `command_2` only if `command_1` has failed (non-zero exit code). Similarly, the `command_1 && command_2` operator means to execute `command_2` only if `command_1` has succeeded. Try this out using one of scripts you made in the previous session:
+The `command_1 || command_2` operator means to execute `command_2` only if `command_1` has failed (non-zero exit code). Similarly, the `command_1 && command_2` operator means to execute `command_2` only if `command_1` has succeeded. Try this out using one of the scripts you made in the previous session:
 
 ~~~
 > ./python_exit.py goodbye || echo ignore
@@ -172,7 +172,7 @@ What does that give you?
 
 > ## Overriding Exit Codes
 >
-> It's not really recommended to 'hack' the exit codes like this, but this example is provided so that you are aware of how to do it, if you ever run into this situation. Assume that scripts respect exit codes, until you run into one that does not.
+> It's not really recommended to 'hack' the exit codes like this, but this example is provided so that you are aware of how to do it if you ever run into this situation. Assume that scripts respect exit codes, until you run into one that does not.
 {: .callout}
 
 {% include links.md %}

--- a/_episodes/02-enter-sandman.md
+++ b/_episodes/02-enter-sandman.md
@@ -168,7 +168,14 @@ To finish up this section, one thing you'll notice sometimes (in ATLAS or CMS) i
 ~~~
 {: .language-bash}
 
-The `command_1 || command_2` operator means to execute `command_2` only if `command_1` has failed (non-zero exit code). Similarly, the `command_1 && command_2` operator means to execute `command_2` only if `command_1` has succeeded. Try this out using one of the scripts you made in the previous session:
+The `command_1 || command_2` OR-operator means to execute `command_2` only if `command_1` has failed (non-zero exit code).
+Similarly, the `command_1 && command_2` AND-operator means to execute `command_2` only if `command_1` has succeeded.
+
+These are both examples of [short-ciruited](https://en.wikipedia.org/wiki/Short-circuit_evaluation) boolean expressions.
+Short-circuited expressions return the result of the boolean expression as soon as the minimal information necessary for the result is computed: the operands are executed from left to right, and the right operand only evaluates if the left operand doesn't determine the answer.
+
+
+Try this out using one of the scripts you made in the previous session:
 
 ~~~
 > ./python_exit.py goodbye || echo ignore

--- a/_episodes/02-enter-sandman.md
+++ b/_episodes/02-enter-sandman.md
@@ -19,6 +19,10 @@ keypoints:
 
 As we enter the first episode of the Continuous Integration / Continuous Deployment (CI/CD) session, we learn how to exit.
 
+Exit codes communicate the outcome of a script with (in this case) the CI/CD pipline.
+We generally want a CI/CD pipeline to fail if one of its components fails.
+For example, you would not usually want to run CD to deploy a custom Docker image if the CI tests fail for the code in that image.
+
 <iframe width="560" height="315" src="https://www.youtube.com/embed/Z7aVq3DNH6U?si=QVvru9yRjsYkupA9" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 # Start by Exiting

--- a/_episodes/02-enter-sandman.md
+++ b/_episodes/02-enter-sandman.md
@@ -93,6 +93,9 @@ and there, the exit code is non-zero -- a failure.
 
 Try out some other commands on your system, and see what things look like.
 
+Some exit codes are recommended to have [special meanings](https://tldp.org/LDP/abs/html/exitcodes.html#EXITCODESREF) by convention, although there is nothing stopping someone from overriding them in their script.
+
+
 # Printing Exit Codes
 
 As you've seen above, the exit code from the last executed command is stored in the `$?` environment variable. Accessing from a shell is easy `echo $?`. What about from Python? There are many different ways depending on which library you use. Using similar examples above, we can use the (note: deprecated) `os.system` call:

--- a/_episodes/02-enter-sandman.md
+++ b/_episodes/02-enter-sandman.md
@@ -164,9 +164,18 @@ and then make it executable `chmod +x python_exit.py`. Now, try running it with 
 To finish up this section, one thing you'll notice sometimes (in ATLAS or CMS) is that a script you run doesn't seem to respect exit codes. A notable example in ATLAS is the use of `setupATLAS` which returns non-zero exit status codes even though it runs successfully! This can be very annoying when you start development with the assumption that exit status codes are meaningful (such as with CI). In these cases, you'll need to ignore the exit code. An easy way to do this is to execute a second command that always gives `exit 0` if the first command doesn't, like so:
 
 ~~~
-> :(){ return 1; };: || echo ignore failure
+> false || echo "ignore failure"
+> echo $?
 ~~~
 {: .language-bash}
+
+~~~
+ignore failure
+0
+~~~
+{: .output}
+
+Where `false` is just a simple command that always returns a non-zero exit code.
 
 The `command_1 || command_2` OR-operator means to execute `command_2` only if `command_1` has failed (non-zero exit code).
 Similarly, the `command_1 && command_2` AND-operator means to execute `command_2` only if `command_1` has succeeded.
@@ -184,7 +193,7 @@ Try this out using one of the scripts you made in the previous session:
 
 What does that give you?
 
-It's possible to ignore an exit code quietly by running `command_1 || true`, where `true` is a simple shell command whose only job is to return an exit code of `0`.
+It's possible to ignore an exit code quietly by running `command_1 || true`, where `true` always returns an exit code of `0`.
 
 
 > ## Overriding Exit Codes

--- a/_episodes/02-enter-sandman.md
+++ b/_episodes/02-enter-sandman.md
@@ -30,7 +30,7 @@ For example, you would not usually want to run CD to deploy a custom Docker imag
 How does a general task know whether or not a script finished correctly or not? You could parse (`grep`) the output:
 
 ~~~
-> ls nonexistent-file
+ls nonexistent-file
 ~~~
 {: .language-bash}
 
@@ -42,8 +42,8 @@ ls: cannot access 'nonexistent-file': No such file or directory
 But every command outputs something differently. Instead, scripts also have an (invisible) exit code:
 
 ~~~
-> ls nonexistent-file
-> echo $?
+ls nonexistent-file
+echo $?
 ~~~
 {: .language-bash}
 
@@ -51,13 +51,13 @@ But every command outputs something differently. Instead, scripts also have an (
 ls: cannot access 'nonexistent-file': No such file or directory
 2
 ~~~
-{: .language-bash}
+{: .output}
 
 The exit code is `2` indicating failure. What about on success? The exit code is `0` like so:
 
 ~~~
-> echo
-> echo $?
+echo
+echo $?
 ~~~
 {: .language-bash}
 
@@ -70,8 +70,8 @@ The exit code is `2` indicating failure. What about on success? The exit code is
 But this works for any command you run on the command line! For example, if I mistyped `git status`:
 
 ~~~
-> git stauts
-> echo $?
+git stauts
+echo $?
 ~~~
 {: .language-bash}
 
@@ -164,8 +164,8 @@ and then make it executable `chmod +x python_exit.py`. Now, try running it with 
 To finish up this section, one thing you'll notice sometimes (in ATLAS or CMS) is that a script you run doesn't seem to respect exit codes. A notable example in ATLAS is the use of `setupATLAS` which returns non-zero exit status codes even though it runs successfully! This can be very annoying when you start development with the assumption that exit status codes are meaningful (such as with CI). In these cases, you'll need to ignore the exit code. An easy way to do this is to execute a second command that always gives `exit 0` if the first command doesn't, like so:
 
 ~~~
-> false || echo "ignore failure"
-> echo $?
+false || echo "ignore failure"
+echo $?
 ~~~
 {: .language-bash}
 
@@ -187,7 +187,7 @@ Short-circuited expressions return the result of the boolean expression as soon 
 Try this out using one of the scripts you made in the previous session:
 
 ~~~
-> ./python_exit.py goodbye || echo ignore
+./python_exit.py goodbye || echo ignore
 ~~~
 {: .language-bash}
 

--- a/_episodes/02-enter-sandman.md
+++ b/_episodes/02-enter-sandman.md
@@ -184,6 +184,9 @@ Try this out using one of the scripts you made in the previous session:
 
 What does that give you?
 
+It's possible to ignore an exit code quietly by running `command_1 || true`, where `true` is a simple shell command whose only job is to return an exit code of `0`.
+
+
 > ## Overriding Exit Codes
 >
 > It's not really recommended to 'hack' the exit codes like this, but this example is provided so that you are aware of how to do it if you ever run into this situation. Assume that scripts respect exit codes, until you run into one that does not.

--- a/_episodes/02-enter-sandman.md
+++ b/_episodes/02-enter-sandman.md
@@ -19,7 +19,7 @@ keypoints:
 
 As we enter the first episode of the Continuous Integration / Continuous Deployment (CI/CD) session, we learn how to exit.
 
-Exit codes communicate the outcome of a script with (in this case) the CI/CD pipline.
+Exit codes communicate the outcome of a script with (in this case) the CI/CD pipeline.
 We generally want a CI/CD pipeline to fail if one of its components fails.
 For example, you would not usually want to run CD to deploy a custom Docker image if the CI tests fail for the code in that image.
 
@@ -70,7 +70,7 @@ echo $?
 But this works for any command you run on the command line! For example, if I mistyped `git status`:
 
 ~~~
-git stauts
+git status
 echo $?
 ~~~
 {: .language-bash}

--- a/_episodes/02-enter-sandman.md
+++ b/_episodes/02-enter-sandman.md
@@ -175,7 +175,7 @@ ignore failure
 ~~~
 {: .output}
 
-Where `false` is just a simple command that always returns a non-zero exit code.
+where `false` is just a simple command that always returns a non-zero exit code.
 
 The `command_1 || command_2` OR-operator means to execute `command_2` only if `command_1` has failed (non-zero exit code).
 Similarly, the `command_1 && command_2` AND-operator means to execute `command_2` only if `command_1` has succeeded.

--- a/_episodes/02-enter-sandman.md
+++ b/_episodes/02-enter-sandman.md
@@ -70,7 +70,7 @@ echo $?
 But this works for any command you run on the command line! For example, if I mistyped `git status`:
 
 ~~~
-git status
+git stauts
 echo $?
 ~~~
 {: .language-bash}

--- a/_episodes/03-understanding-yaml.md
+++ b/_episodes/03-understanding-yaml.md
@@ -3,12 +3,12 @@ title: "Understanding Yet Another Markup Language"
 teaching: 5
 exercises: 0
 objectives:
-  - Learn about YAML
+  - Learn about YAML.
 questions:
   - What is YAML?
 hidden: false
 keypoints:
-  - YAML is a plain-text format, similar to JSON, useful for configuration
+  - YAML is a plain-text format, similar to JSON, useful for configuration.
   - YAML is a superset of JSON, so it contains additional features like comments and anchors, while still supporting JSON.
 ---
 
@@ -153,7 +153,7 @@ foo: bar # this is a comment, too
 
 > ## Anchors
 >
-> YAML also has a handy feature called 'anchors', which let you easily duplicate content across your document. Anchors look like references `&` in C/C++ and named anchors can be dereferenced using `*`.
+> YAML also has a handy feature called 'anchors', which lets you easily duplicate content across your document. Anchors look like references `&` in C/C++ and named anchors can be dereferenced using `*`.
 >
 > ~~~
 > anchored_content: &anchor_name This string will appear as the value of two keys.

--- a/_episodes/04-understanding-yaml-and-ci.md
+++ b/_episodes/04-understanding-yaml-and-ci.md
@@ -115,7 +115,7 @@ job_2:
 
 ## Job Parameters
 
-What are some of the parameters that can be used in a job? Rather than copy/pasting from the reference (linked below in this session), we'll go to the [Configuration parameters](https://docs.gitlab.com/ee/ci/yaml/#configuration-parameters) section in the GitLab docs. The most important parameter, and the only one needed to define a job, is `script`
+What are some of the parameters that can be used in a job? Rather than copy/pasting from the [documentation](#documentation), we'll go to the [Configuration parameters](https://docs.gitlab.com/ee/ci/yaml/#configuration-parameters) section in the GitLab docs. The most important parameter, and the only one needed to define a job, is `script`
 
 ```yml
 job one:

--- a/_episodes/06-hello-world-ci.md
+++ b/_episodes/06-hello-world-ci.md
@@ -16,7 +16,7 @@ keypoints:
 
 # Adding CI/CD to a project
 
-We've been working on the analysis code, which has a lot of work done, but we should be good physicists (and people) by adding tests and CI/CD. The first thing we'll do is create a `.gitlab-ci.yml` file in the project.
+The first thing we'll do is create a `.gitlab-ci.yml` file in the project.
 
 ~~~
 cd virtual-pipelines-eventselection/

--- a/_episodes/06-hello-world-ci.md
+++ b/_episodes/06-hello-world-ci.md
@@ -16,7 +16,7 @@ keypoints:
 
 # Adding CI/CD to a project
 
-We've been working on the analysis code which has a lot of work done, but we should be good physicists (and people) by adding tests and CI/CD. The first thing we'll do is create a `.gitlab-ci.yml` file in the project.
+We've been working on the analysis code, which has a lot of work done, but we should be good physicists (and people) by adding tests and CI/CD. The first thing we'll do is create a `.gitlab-ci.yml` file in the project.
 
 ~~~
 cd virtual-pipelines-eventselection/
@@ -81,7 +81,7 @@ hello world:
 ~~~
 {: .language-yaml}
 
-Before we commit it, since we're still new to CI/CD, let's copy/paste it into the CI linter and make sure it lints correctly
+Before we commit it, since we're still new to CI/CD, let's copy/paste it into the CI linter and make sure it lints correctly.
 
 ![CI/CD Hello World Lint]({{site.baseurl}}/fig/ci-cd-hello-world-lint.png)
 
@@ -100,7 +100,7 @@ Now we want to make sure that this worked. How can we check the status of commit
 
 ## Checking Job's Output
 
-From any of these pages, click through until you can find the output for the successful job run which should look like the following
+From any of these pages, click through until you can find the output for the successful job run, which should look like the following:
 
 ![CI/CD Hello World Success Output]({{site.baseurl}}/fig/ci-cd-hello-world-success-output.png)
 

--- a/_episodes/07-adding-ci-to-your-code.md
+++ b/_episodes/07-adding-ci-to-your-code.md
@@ -223,7 +223,7 @@ build_skim_latest:
 > ~~~
 > {: .language-yaml}
 >
-> and this will build a new version with `./skim` only if the `skim.cxx` file changes. There's plenty more one can do with this that doesn't fit in the limited time for the sessions today, so feel free to try it out on your own time.
+> and this will build a new version with `./skim` only if the `skim.cxx` file changes. There's plenty more one can do with this that doesn't fit into this lesson, so feel free to try it out on your own time.
 {: .callout}
 
 

--- a/_episodes/07-adding-ci-to-your-code.md
+++ b/_episodes/07-adding-ci-to-your-code.md
@@ -3,15 +3,15 @@ title: "Adding CI to Your Existing Code"
 teaching: 5
 exercises: 10
 objectives:
-  - Learn how to get your CI/CD Runners to build your code
+  - Learn how to get your CI/CD Runners to build your code.
   - Try and see if the CI/CD can catch problems with our code.
 questions:
   - I have code already in GitLab, how can I add CI to it?
 hidden: false
 keypoints:
-  - Setting up CI/CD shouldn't be mind-numbing
-  - All defined jobs run in parallel by default
-  - Jobs can be allowed to fail without breaking your CI/CD
+  - Setting up CI/CD shouldn't be mind-numbing.
+  - All defined jobs run in parallel by default.
+  - Jobs can be allowed to fail without breaking your CI/CD.
 ---
 <iframe width="560" height="315" src="https://www.youtube.com/embed/F21FprczK4c?si=JC-wpc-135p7nbp6" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
@@ -93,7 +93,7 @@ Ok, so maybe we were a little naive here. Let's start debugging. You got this er
 
 > ## Answer
 >  It turns out we didn't have ROOT installed.
->  How do we fix it? We need to download and install the miniforge installer. The `-b -p` options specify a batch mode installation without user interaction, and the installation path is set to `$HOME/miniconda`. Setup the conda environment and initialize conda. Then install ROOT with conda and verify the installation with a python script.
+>  How do we fix it? We need to download and install the miniforge installer. The `-b -p` options specify a batch mode installation without user interaction, and the installation path is set to `$HOME/miniconda`. Set up the conda environment and initialize conda. Then install ROOT with conda and verify the installation with a Python script.
 >
 > ```yml
 > hello_world:
@@ -174,7 +174,7 @@ Great, so we finally got it working... CI/CD isn't obviously powerful when you'r
 > {: .solution}
 {: .challenge}
 
-However, we probably don't want our CI/CD to crash if one of the jobs fails. So let's also add `:build_skim_latest:allow_failure = true` to our job as well. This allows the job to fail without crashing the CI/CD -- that is, it's an acceptable failure. This indicates to us when we do something in the code that might potentially break the latest release; or indicate when our code will not build in a new release.
+However, we probably don't want our CI/CD to crash if one of the jobs fails. So let's also add `:build_skim_latest:allow_failure = true` to our job as well. This allows the job to fail without crashing the CI/CD -- that is, it's an acceptable failure. This indicates to us when we do something in the code that might potentially break the latest release, or indicate when our code will not build in a new release.
 
 ~~~yml
 build_skim_latest:
@@ -184,7 +184,7 @@ build_skim_latest:
 ~~~
 
 
-Finally, we want to clean up the two jobs a little by separating out the  miniconda download into a `before_script` and initialization  since this is actually preparation for setting up our environment -- rather than part of the script we want to test! For example,
+Finally, we want to clean up the two jobs a little by separating out the  miniconda download into a `before_script` and initialization, since this is actually preparation for setting up our environment -- rather than part of the script we want to test! For example,
 
 ~~~yml
 build_skim_latest:

--- a/_episodes/08-eins-zwei-dry.md
+++ b/_episodes/08-eins-zwei-dry.md
@@ -3,8 +3,8 @@ title: "Eins Zwei DRY"
 teaching: 5
 exercises: 10
 objectives:
-  - Don't Repeat Yourself (DRY)
-  - Making reusable/flexible CI/CD jobs
+  - Don't Repeat Yourself (DRY).
+  - Make reusable/flexible CI/CD jobs.
 questions:
   - How can we make job templates?
 hidden: false
@@ -19,7 +19,7 @@ keypoints:
 
 # Hidden (keys) Jobs
 
-A fun [feature](https://docs.gitlab.com/ee/ci/yaml/README.html#special-yaml-features) about GitLab's CI YAML is the ability to disable entire jobs simply by prefixing the job name with a period (`.`). Naively, we could just comment it out
+A fun [feature](https://docs.gitlab.com/ee/ci/yaml/README.html#special-yaml-features) about GitLab's CI YAML is the ability to disable entire jobs simply by prefixing the job name with a period (`.`). Naively, we could just comment it out.
 
 ~~~
 #hidden job:

--- a/_episodes/08b-matrix.md
+++ b/_episodes/08b-matrix.md
@@ -203,7 +203,7 @@ multi_build:
 
 
 > ## Note
-> 1. We have only defined a `ROOT_VERS` list, and we use this in the `before_script` section to set up the instalation of ROOT.  After testing it we can see that this works and we've been able to reduce the amount of text a lot more.
+> 1. We have only defined a `ROOT_VERS` list, and we use this in the `before_script` section to set up the installation of ROOT.  After testing it we can see that this works and we've been able to reduce the amount of text a lot more.
 > 2. We have dropped the `allow_failure: yes` for now because we're feeling confident.
 > 3. We have factored out the `before_script` and the `script` into our `.build_template`.
 {: .callout}

--- a/_episodes/08b-matrix.md
+++ b/_episodes/08b-matrix.md
@@ -32,7 +32,7 @@ test:
 A pipeline with jobs that use parallel might:
 
 - Create more jobs running in parallel than available runners. Excess jobs are queued and marked pending while waiting for an available runner.
-- Create too many jobs, and the pipeline fails with a `job_activity_limit_exceeded` error. The maximum number of jobs that can exist in active pipelines is [limited at the instance-level](https://docs.gitlab.com/ee/administration/instance_limits.html#number-of-jobs-in-active-pipelines).
+- Create too many jobs, and the pipeline fails with a `job_activity_limit_exceeded` error. The maximum number of jobs that can exist in active pipelines is [limited at the GitLab-instance level](https://docs.gitlab.com/ee/administration/instance_limits.html#number-of-jobs-in-active-pipelines).
 
 
 ## Matrices
@@ -54,7 +54,7 @@ test_build:
     - echo "My $my_os build"
   parallel:
     matrix:
-      - my_os: [Windows,Linux,MacOS]
+      - my_os: [Windows, Linux, MacOS]
 
 ```
 
@@ -70,8 +70,8 @@ test_build:
     - echo "My $my_os build"
   parallel:
     matrix:
-      - my_os: [Windows,Linux,MacOS]
-        version: ["12.0","14.2"]
+      - my_os: [Windows, Linux, MacOS]
+        version: ["12.0", "14.2"]
 ```
 
 ![Parallel OS with versions]({{site.baseurl}}/fig/parallel-versions.png){: width="60%"}
@@ -85,11 +85,11 @@ test_build:
   parallel:
     matrix:
       - my_os: Windows
-        version: ["10","11"]
+        version: ["10", "11"]
       - my_os: Linux
         version: "Ubuntu-22.04LTS"
       - my_os: MacOS
-        version: ["Sonoma","Ventura"]
+        version: ["Sonoma", "Ventura"]
 ```
 
 ![Specified OS and version pairs]({{site.baseurl}}/fig/parallel-specified.png){: width="60%"}
@@ -126,11 +126,11 @@ What this means is that we can access the values from the variable `my_os` and d
 >   parallel:
 >     matrix:
 >       - my_os: Windows
->         version: ["10","11"]
+>         version: ["10", "11"]
 >       - my_os: Linux
 >         version: "Ubuntu-22.04LTS"
 >       - my_os: MacOS
->         version: ["Sonoma","Ventura"]
+>         version: ["Sonoma", "Ventura"]
 > ```
 {: .callout}
 
@@ -198,7 +198,7 @@ multi_build:
   extends: .template_build
   parallel:
     matrix:
-      - ROOT_VERS: ["root=6.28","root"]
+      - ROOT_VERS: ["root=6.28", "root"]
 ```
 
 

--- a/_episodes/08b-matrix.md
+++ b/_episodes/08b-matrix.md
@@ -3,21 +3,21 @@ title: "Even more builds"
 teaching: 10
 exercises: 5
 objectives:
-  - Matrix workflows
-  - Making reusable/flexible CI/CD jobs
+  - Matrix workflows.
+  - Make reusable/flexible CI/CD jobs.
 questions:
   - How can we make variations of our builds?
 hidden: false
 keypoints:
-  - Matrices can help make many builds with variations
-  - Use Variables whenever it's convenient
+  - Matrices can help make many builds with variations.
+  - Use Variables whenever it's convenient.
 ---
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/pdV1nrOvMA8?si=I2nJwEDRGt3Hga4b" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 # Parallel and  Matrix jobs
 
-Matrices are one of the fundamental concepts of CIs. They allow for flexible workflows that involve building or running scripts with many variations in a few lines. In Gitlab, we need to use the `parallel` keyword to run a job multiple times in parallel in a single pipeline.
+Matrices are one of the fundamental concepts of CIs. They allow for flexible workflows that involve building or running scripts with many variations in a few lines. In GitLab, we need to use the `parallel` keyword to run a job multiple times in parallel in a single pipeline.
 
 This example creates 5 jobs that run in parallel, named `test 1/5` to `test 5/5`.
 
@@ -37,10 +37,10 @@ A pipeline with jobs that use parallel might:
 
 ## Matrices
 
-It's not really useful to simply repeat the same exact job, it is far more useful if each job can be different.
+It's not really useful to simply repeat the same exact job; it is far more useful if each job can be different.
 Use `parallel:matrix` to run a job multiple times in parallel in a single pipeline, but with different variable values for each instance of the job. Some conditions on the possible inputs are:
 - The variable names can use only numbers, letters, and underscores `_`.
-- The values must be either a string, or an array of strings.
+- The values must be either a string or an array of strings.
 - The number of permutations cannot exceed 200.
 
 In order to make use of `parallel:matrix` let's give a list of dictionaries that simulate a build running on Windows, Linux or MacOS.
@@ -77,7 +77,7 @@ test_build:
 ![Parallel OS with versions]({{site.baseurl}}/fig/parallel-versions.png){: width="60%"}
 
 
-If you want to specify different OS and version pairs you can do that as well.
+If you want to specify different OS and version pairs, you can do that as well.
 ```yml
 test_build:
   script:
@@ -97,7 +97,7 @@ test_build:
 
 ## Variables
 
-You might have noticed that we use `$my_os` in the script above. If we take a look at one of the logs it shows that we have obtained the following output
+You might have noticed that we use `$my_os` in the script above. If we take a look at one of the logs it shows that we have obtained the following output.
 ```
 Executing "step_script" stage of the job script 00:00
 $ # INFO: Lowering limit of file descriptors for backwards compatibility. ffi: https://cern.ch/gitlab-runners-limit-file-descriptors # collapsed multi-line command
@@ -109,7 +109,7 @@ Job succeeded
 {: .output}
 
 
-What this means is that we can access the values from the variable `my_os` and do something with it! This is very handy as you will see. Not only can we access values from the yml but we can create global variables that remain constant for the entire process.
+What this means is that we can access the values from the variable `my_os` and do something with it! This is very handy, as you will see. Not only can we access values from the yml but we can create global variables that remain constant for the entire process.
 
 > ## Example
 > ```yml
@@ -137,7 +137,7 @@ What this means is that we can access the values from the variable `my_os` and d
 
 # Mix it all up and write less code!
 
-Let's now mix the usage of parallel jobs and the the fact that we can exctrat values from variables we defined.
+Let's now mix the usage of parallel jobs and the fact that we can extract values from variables we defined.
 Let's try implementing this with the config file we've been developing so far.
 
 > ## Remember what we have so far
@@ -175,7 +175,7 @@ Let's try implementing this with the config file we've been developing so far.
 > ```
 {: .solution}
 
-Now let's apply what we learned to refactor and reduce the code all into a single job named `multi_build`.
+Now let's apply what we learned to refactor and reduce the code into a single job named `multi_build`.
 
 ```yml
 hello_world:
@@ -203,7 +203,7 @@ multi_build:
 
 
 > ## Note
-> 1. We have only defined a `ROOT_VERS` list and we use this in the `before_script` section to setup the intalation of ROOT.  After testing it we can see that this works and we've been able to reduce the amount of text a lot more.
+> 1. We have only defined a `ROOT_VERS` list, and we use this in the `before_script` section to set up the instalation of ROOT.  After testing it we can see that this works and we've been able to reduce the amount of text a lot more.
 > 2. We have dropped the `allow_failure: yes` for now because we're feeling confident.
 > 3. We have factored out the `before_script` and the `script` into our `.build_template`.
 {: .callout}

--- a/_episodes/08c-images.md
+++ b/_episodes/08c-images.md
@@ -3,13 +3,13 @@ title: "Building with Images"
 teaching: 10
 exercises: 5
 objectives:
-  - Use docker images
-  - Making reusable/flexible CI/CD jobs
+  - Use Docker images.
+  - Make reusable/flexible CI/CD jobs.
 questions:
-  - Can we use docker images to ease our setup?
+  - Can we use Docker images to ease our setup?
 hidden: false
 keypoints:
-  - We can shorten a lot of the setup with Docker images
+  - We can shorten a lot of the setup with Docker images.
 ---
 <iframe width="560" height="315" src="https://www.youtube.com/embed/mWUyoFwjxto?si=TGVrpH2BZzsS-f80" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
@@ -17,7 +17,7 @@ keypoints:
 
 While we won't be going into detail about containers (for that check [our Docker lesson](https://hsf-training.github.io/hsf-training-docker/)), we've been using them all this time with Gitlab. Gitlab runners are working within a barebones virtual environment that runs Linux, and is itself an image.
 
-Naturally, we can leverage the fact that Gitlab runners can run Docker to further simplify setting up the working environment. This is done using the `image` keyword. The input for `image` is the name of the image, including the registry path if needed, in one of these formats:
+Naturally, we can leverage the fact that GitLab runners can run Docker to further simplify setting up the working environment. This is done using the `image` keyword. The input for `image` is the name of the image, including the registry path if needed, in one of these formats:
 
 - `<image-name>` (Same as using `<image-name>` with the latest tag)
 - `<image-name>:<tag>`
@@ -45,7 +45,7 @@ tests:
 
 # Back to our CI file
 
-Go to the ROOT docker hub page <https://hub.docker.com/r/rootproject/root> and choose a version any version you wish to try.
+Go to the ROOT Docker Hub page <https://hub.docker.com/r/rootproject/root> and choose a version any version you wish to try.
 
 Let's add `image: $ROOT_IMAGE` because we can still use `parallel:matrix:` to make various builds easily.
 Since we're going to use a docker image to have a working version of ROOT, we can omit the lines that install and set up conda and ROOT.
@@ -73,9 +73,9 @@ multi_build:
 
 
 > ## Note
->  We used the `latest` docker image and an `ubuntu` image in this particular example but the script remains the same
->  regardless if you wish to use the conda build or an ubuntu build of ROOT.
+>  We used the `latest` Docker image and an `Ubuntu` image in this particular example but the script remains the same
+>  regardless if you wish to use the conda build or an Ubuntu build of ROOT.
 >
-> Make sure your image works with the CI, not all images listed in the [rootproject's docker hub](https://hub.docker.com/r/rootproject/root) work 100% of the time.
+> Make sure your image works with the CI; not all images listed in the [rootproject's Docker Hub](https://hub.docker.com/r/rootproject/root) work 100% of the time.
 >
 {: .callout}

--- a/_episodes/09-coffee.md
+++ b/_episodes/09-coffee.md
@@ -7,7 +7,7 @@ questions:
 objectives:
 - "Refresh your mind."
 keypoints:
-- Stupid mistakes happen, but telling a computer to do what you mean versus what you say is hard
+- Stupid mistakes happen, but telling a computer to do what you mean versus what you say is hard.
 ---
 
 <center>

--- a/_episodes/10-the-worlds-a-stage.md
+++ b/_episodes/10-the-worlds-a-stage.md
@@ -98,7 +98,7 @@ Now all jobs in `greeting` run first, before all jobs in `build` (as this is the
 > - `test`
 > - `deploy`
 > - `.post`
-> 
+>
 > When you define your own `stages`, as we've done above by adding `greetings` and `build`, the `.pre` and  `.post` stages remain, while the others are overwritten. So, in our example above, the stages available are
 > - `.pre`
 > - `greetings`

--- a/_episodes/10-the-worlds-a-stage.md
+++ b/_episodes/10-the-worlds-a-stage.md
@@ -43,9 +43,9 @@ We're going to talk about another global parameter `:stages` (and the associated
 
 ![CI/CD Default Stages in Pipeline]({{site.baseurl}}/fig/ci-cd-default-stages.png)
 
-> ## Default Stage
+> ## Default job stage
 >
-> You'll note that the default stage is `test`. Of course, for CI/CD, this is likely the most obvious choice.
+> You'll note that the default job stage is `test`. Of course, for CI/CD, this is likely the most obvious choice.
 {: .callout}
 
 Stages allow us to categorize jobs by functionality, such as `build`, `test`, or `deploy` -- with job names being the next level of specification, such as `test_cpp`, `build_current`, `build_latest`, or `deploy_pages`. Remember that two jobs cannot have the same name (globally), no matter what stage they're in. Like the other global parameter `variables`, we keep `stages` towards the top of our `.gitlab-ci.yml` file.
@@ -89,6 +89,27 @@ If you do it correctly, you should see a pipeline graph with two stages.
 ![CI/CD Pipeline Two Stages]({{site.baseurl}}/fig/ci-cd-pipeline-two-stages.png)
 
 Now all jobs in `greeting` run first, before all jobs in `build` (as this is the order we've defined our stages). All jobs within a given stage run in parallel as well.
+
+
+> ## Default CI/CD stages
+> The default stages are
+> - `.pre`
+> - `build`
+> - `test`
+> - `deploy`
+> - `.post`
+> 
+> When you define your own `stages`, as we've done above by adding `greetings` and `build`, the `.pre` and  `.post` stages remain, while the others are overwritten. So, in our example above, the stages available are
+> - `.pre`
+> - `greetings`
+> - `build`
+> - `.post`
+>
+> But, only the stages with jobs are used.
+>
+{: .callout}
+
+
 
 That's it. There's nothing more to `stages` apart from that! In fact, everything in terms of parallel/serial as well as job dependencies only make sense in the context of having multiple stages. In all the previous sessions, you've just been using the default `test` stage for all jobs; the jobs all ran in parallel.
 

--- a/_episodes/10-the-worlds-a-stage.md
+++ b/_episodes/10-the-worlds-a-stage.md
@@ -38,7 +38,7 @@ multi_build:
 ```
 
 
-We're going to talk about another global parameter `:stages` (and the associated per-job parameter `:job:stage`. Stages allow us to group up parallel jobs with each group running after the other in the order you define. What have our jobs looked like so far in the pipelines we've been running?
+We're going to talk about another global parameter `:stages` (and the associated per-job parameter `:job:stage`. Stages allow us to group up parallel jobs, with each group running after the other in the order you define. What have our jobs looked like so far in the pipelines we've been running?
 
 
 ![CI/CD Default Stages in Pipeline]({{site.baseurl}}/fig/ci-cd-default-stages.png)
@@ -48,7 +48,7 @@ We're going to talk about another global parameter `:stages` (and the associated
 > You'll note that the default stage is `test`. Of course, for CI/CD, this is likely the most obvious choice.
 {: .callout}
 
-Stages allow us to categorize jobs by functionality, such as `build`, or `test`, or `deploy` -- with job names being the next level of specification such as `test_cpp`, `build_current`, `build_latest`, or `deploy_pages`. Remember that two jobs cannot have the same name (globally), no matter what stage they're in. Like the other global parameter `variables`, we keep `stages` towards the top of our `.gitlab-ci.yml` file.
+Stages allow us to categorize jobs by functionality, such as `build`, `test`, or `deploy` -- with job names being the next level of specification, such as `test_cpp`, `build_current`, `build_latest`, or `deploy_pages`. Remember that two jobs cannot have the same name (globally), no matter what stage they're in. Like the other global parameter `variables`, we keep `stages` towards the top of our `.gitlab-ci.yml` file.
 
 > ## Adding Stages
 >
@@ -84,7 +84,7 @@ Stages allow us to categorize jobs by functionality, such as `build`, or `test`,
 > {: .solution}
 {: .challenge}
 
-If you do it correctly, you should see a pipeline graph with two stages
+If you do it correctly, you should see a pipeline graph with two stages.
 
 ![CI/CD Pipeline Two Stages]({{site.baseurl}}/fig/ci-cd-pipeline-two-stages.png)
 

--- a/_episodes/10-the-worlds-a-stage.md
+++ b/_episodes/10-the-worlds-a-stage.md
@@ -34,7 +34,7 @@ multi_build:
   image: $ROOT_IMAGE
   parallel:
     matrix:
-      - ROOT_IMAGE: ["rootproject/root:6.28.10-ubuntu22.04","rootproject/root:latest"]
+      - ROOT_IMAGE: ["rootproject/root:6.28.10-ubuntu22.04", "rootproject/root:latest"]
 ```
 
 
@@ -78,7 +78,7 @@ Stages allow us to categorize jobs by functionality, such as `build`, `test`, or
 > >   image: $ROOT_IMAGE
 > >   parallel:
 > >     matrix:
-> >       - ROOT_IMAGE: ["rootproject/root:6.28.10-ubuntu22.04","rootproject/root:latest"]
+> >       - ROOT_IMAGE: ["rootproject/root:6.28.10-ubuntu22.04", "rootproject/root:latest"]
 > > ~~~
 > > {: .language-yaml}
 > {: .solution}

--- a/_episodes/11-skim-milk.md
+++ b/_episodes/11-skim-milk.md
@@ -41,7 +41,7 @@ multi_build:
   image: $ROOT_IMAGE
   parallel:
     matrix:
-      - ROOT_IMAGE: ["rootproject/root:6.28.10-ubuntu22.04","rootproject/root:latest"]
+      - ROOT_IMAGE: ["rootproject/root:6.28.10-ubuntu22.04", "rootproject/root:latest"]
 ```
 
 So we need to do two things:

--- a/_episodes/11-skim-milk.md
+++ b/_episodes/11-skim-milk.md
@@ -16,7 +16,7 @@ keypoints:
 
 # The First Naive Attempt
 
-Let's just attempt to try and get the code working as it is. Since it worked for us already locally, surely the CI/CD must be able to run it??? As a reminder of what we've ended with from the last session:
+Let's just attempt to try and get the code working as it is. Since it worked for us already locally, surely the CI/CD must be able to run it??? As a reminder of what we ended with from the last session:
 
 ```yml
 stages:
@@ -46,10 +46,10 @@ multi_build:
 
 So we need to do two things:
 
-1. add a `run` stage
-2. add a `skim_ggH` job to this stage
+1. Add a `run` stage
+2. Add a `skim_ggH` job to this stage
 
-Let's go ahead and do that, so we now have three stages
+Let's go ahead and do that, so we now have three stages.
 
 ```
 stages:
@@ -79,12 +79,12 @@ skim_ggH:
 
 Ok, fine. That was way too easy. It seems we have a few issues to deal with.
 
-1. The code in the `multi_build` jobs (of the `build` stage) isn't in the `skim_ggH` job by default. We need to use GitLab `artifacts` to copy over this from the one of the jobs (let's choose as an example the `multi_build: [rootproject/root:6.28.10-ubuntu22.04]` job).
+1. The code in the `multi_build` jobs (of the `build` stage) isn't in the `skim_ggH` job by default. We need to use GitLab `artifacts` to copy over this from one of the jobs (let's choose as an example the `multi_build: [rootproject/root:6.28.10-ubuntu22.04]` job).
 2. The data (ROOT file) isn't available to the Runner yet.
 
 ## Artifacts
 
-`artifacts` is used to specify a list of files and directories which should be attached to the job when it succeeds, fails, or always. The artifacts will be sent to GitLab after the job finishes and will be available for download in the GitLab UI.
+`artifacts` is used to specify a list of files and directories that should be attached to the job when it succeeds, fails, or always. The artifacts will be sent to GitLab after the job finishes and will be available for download in the GitLab UI.
 
 > ## More Reading
 > - [https://docs.gitlab.com/ee/ci/pipelines/job_artifacts.html](https://docs.gitlab.com/ee/ci/pipelines/job_artifacts.html)
@@ -99,7 +99,7 @@ Artifacts are the way to transfer files between jobs of different stages. In ord
 
 > ## Using Dependencies
 >
-> To use this feature, define `dependencies` in context of the job and pass a list of all previous jobs from which the artifacts should be downloaded. You can only define jobs from stages that are executed before the current one. An error will be shown if you define jobs from the current stage or next ones. Defining an empty array will skip downloading any artifacts for that job. The status of the previous job is not considered when using `dependencies`, so if it failed or it is a manual job that was not run, no error occurs.
+> To use this feature, define `dependencies` in the context of the job and pass a list of all previous jobs from which the artifacts should be downloaded. You can only define jobs from stages that are executed before the current one. An error will be shown if you define jobs from the current stage or the next ones. Defining an empty array will skip downloading any artifacts for that job. The status of the previous job is not considered when using `dependencies`, so if it failed or is a manual job that was not run, no error occurs.
 {: .callout}
 
 > ## Don't want to use dependencies?
@@ -120,7 +120,7 @@ Since the build artifacts don't need to exist for more than a day, let's add art
 
 > ## Adding Artifacts
 >
-> Let's add `artifacts` to our jobs to save the `skim` binary. We'll also make sure the `skim_ggH` job has the right `dependencies` as well. In this case the job `multi_build` is actually running two parallel jobs: one for the ROOT version 6.28 and the other for the latest version of ROOT. So we have to make sure we specify the right dependency as `"multi_build: [rootproject/root:6.28.10-ubuntu22.04]"`.
+> Let's add `artifacts` to our jobs to save the `skim` binary. We'll also make sure the `skim_ggH` job has the right `dependencies` as well. In this case, the job `multi_build` is actually running two parallel jobs: one for the ROOT version 6.28 and the other for the latest version of ROOT. So we have to make sure we specify the right dependency as `"multi_build: [rootproject/root:6.28.10-ubuntu22.04]"`.
 >
 > > ## Solution
 > > ```
@@ -177,17 +177,17 @@ Ok, it looks like the CI failed because it couldn't find the shared libraries. W
 
 So now we've dealt with the first problem of getting the built code available to the `skim_ggH` job via `artifacts` and `dependencies`. Now we need to think about how to get the data in. We could:
 
-- `wget` the entire ROOT file every time
-- `git commit` the ROOT file into the repo
-  - ok, maybe not our repo, but another repo that you can add as a submodule so you don't have to clone it every time
-- fine, maybe we can make a smaller ROOT file
-- what? we don't have time to cover that? ok, can we use `xrdcp`?
-- yes, I realize it's a big ROOT file but still...
+- `wget` the entire ROOT file every time.
+- `git commit` the ROOT file into the repo.
+  - ok, maybe not our repo, but another repo that you can add as a submodule so you don't have to clone it every time.
+- Fine, maybe we can make a smaller ROOT file.
+- What? don't we have time to cover that? ok, can we use `xrdcp`?
+- Yes, I realize it's a big ROOT file, but still...
 
-Anyway, there's lots of options. For large (ROOT) files, it's usually preferable to either
+Anyway, there are lots of options. For large (ROOT) files, it's usually preferable to either.
 
-- stream the file event-by-event (or chunks of events at a time) and only process a small number of events
-- download a small file that you process entirely
+- Stream the file event-by-event (or chunks of events at a time) and only process a small number of events.
+- Download a small file that you process entirely.
 
 The `xrdcp` option is going to be much easier to deal with in the long run, especially as the data file is on eos.
 
@@ -251,7 +251,7 @@ skim_ggH:
 
 > ## How many events to run over?
 >
-> For CI jobs, we want things to run fast and have fast turnaround time. More especially since everyone at CERN shares a pool of runners for most CI jobs, so we should be courteous about the run time of our CI jobs. I generally suggest running over just enough events for you to be able to test what you want to test - whether cutflow or weights.
+> For CI jobs, we want things to run fast and have a fast turnaround time. More especially since everyone at CERN shares a pool of runners for most CI jobs, so we should be courteous about the run time of our CI jobs. I generally suggest running over just enough events for you to be able to test what you want to test - whether cutflow or weights.
 {: .callout}
 
 Let's go ahead and commit those changes and see if the run job succeeded or not.

--- a/_episodes/12-the-spy-game.md
+++ b/_episodes/12-the-spy-game.md
@@ -61,7 +61,7 @@ So we need to give our CI/CD access to our data. This is actually a good thing. 
 >
 > When you're dealing with a personal repository (project) that nobody else has administrative access to, e.g., the settings, then it's *ok* to use your CERN account/password in the environment variables for the settings...
 >
-> However, when you're sharing or part of a group, it is much better to use a group's service account or a user's (maybe yours) service account for authentication instead. For today's lesson however, we'll be using your account and show pictures of how to set these environment variables.
+> However, when you're sharing or part of a group, it is much better to use a group's service account or a user's (maybe yours) service account for authentication instead. For this lesson however, we'll be using your account and show pictures of how to set these environment variables.
 {: .callout}
 
 > ## How to make a service account?

--- a/_episodes/12-the-spy-game.md
+++ b/_episodes/12-the-spy-game.md
@@ -3,21 +3,21 @@ title: "Getting into the Spy Game (Optional)"
 teaching: 5
 exercises: 10
 objectives:
-  - Add custom environment variables
-  - Learn how to give your CI/CD Runners access to private information
+  - Add custom environment variables.
+  - Learn how to give your CI/CD Runners access to private information.
 questions:
   - How can I give my GitLab CI job private information?
 hidden: false
 keypoints:
-  - Service accounts provide an extra layer of security between the outside world and your account
-  - Environment variables in GitLab CI/CD allow you to hide protected information from others who can see your code
+  - Service accounts provide an extra layer of security between the outside world and your account.
+  - Environment variables in GitLab CI/CD allow you to hide protected information from others who can see your code.
 ---
 
 
 
-Note that you need to follow the steps in this chapter only if you are trying to use the file in CERN restricted space. If you used the file in public space you can skip to the next chapter.
+Note that you need to follow the steps in this chapter only if you are trying to use the file in the CERN restricted space. If you used the file in a public space, you can skip to the next chapter.
 
-So we're nearly done with getting the merge request for the CI/CD up and running but we need to deal with this error:
+So we're nearly done with getting the merge request for the CI/CD up and running, but we need to deal with this error:
 
 ~~~
 $ ./skim root://eosuser.cern.ch//eos/user/g/gstark/AwesomeWorkshopFeb2020/GluGluToHToTauTau.root skim_ggH.root 19.6 11467.0 0.1
@@ -59,7 +59,7 @@ So we need to give our CI/CD access to our data. This is actually a good thing. 
 
 > ## Service Account or Not?
 >
-> When you're dealing with a personal repository (project) that nobody else has administrative access to, e.g. the settings, then it's *ok* to use your CERN account/password in the environment variables for the settings...
+> When you're dealing with a personal repository (project) that nobody else has administrative access to, e.g., the settings, then it's *ok* to use your CERN account/password in the environment variables for the settings...
 >
 > However, when you're sharing or part of a group, it is much better to use a group's service account or a user's (maybe yours) service account for authentication instead. For today's lesson however, we'll be using your account and show pictures of how to set these environment variables.
 {: .callout}
@@ -111,13 +111,13 @@ Let's go ahead and add some custom variables to fix up our access control.
 
 # Adding `kinit` for access control
 
-Now it's time to update your CI/CD to use the environment variables you defined by adding `printf $SERVICE_PASS | base64 -d | kinit $CERN_USER@CERN.CH` as part of the `before_script` to the `skim_ggH` job as that's the job that requires access.
+Now it's time to update your CI/CD to use the environment variables you defined by adding `printf $SERVICE_PASS | base64 -d | kinit $CERN_USER@CERN.CH` as part of the `before_script` to the `skim_ggH` job, as that's the job that requires access.
 
-At this point it's also important to note that we will need a root container which has kerberos tools installed. So just for this exercise we will switch to another docker image, `root:6.26.10-conda`, which has those tools. In the rest of the chapters we use examples with files in public space, so you won't need kerberos tools.
+At this point, it's also important to note that we will need a root container which has kerberos tools installed. So just for this exercise we will switch to another Docker image, `root:6.26.10-conda`, which has those tools. In the rest of the chapters we use examples with files in public space, so you won't need kerberos tools.
 
 # Adding Artifacts on Success
 
-As it seems like we have a complete CI/CD that does physics - we should see what came out. We just need to add artifacts for the `skim_ggH` job. This is left as an exercise to you.
+As it seems like we have a complete CI/CD that does physics, we should see what came out. We just need to add artifacts for the `skim_ggH` job. This is left as an exercise to you.
 
 > ## Adding Artifacts
 >

--- a/_episodes/12-the-spy-game.md
+++ b/_episodes/12-the-spy-game.md
@@ -152,7 +152,7 @@ As it seems like we have a complete CI/CD that does physics, we should see what 
 > >   image: $ROOT_IMAGE
 > >   parallel:
 > >     matrix:
-> >       - ROOT_IMAGE: ["rootproject/root:6.26.10-conda","rootproject/root:latest"]
+> >       - ROOT_IMAGE: ["rootproject/root:6.26.10-conda", "rootproject/root:latest"]
 > >
 > > skim_ggH:
 > >   stage: run
@@ -183,7 +183,6 @@ or if you click through to a `skim_ggH` job, you can browse the artifacts
 which should just be the `skim_ggH.root` file you just made.
 
 > ## Further Reading
-> - <https://gitlab.cern.ch/help/ci/variables/README#variables>
 > - <https://gitlab.cern.ch/help/ci/variables/predefined_variables.md>
 {: .checklist}
 

--- a/_episodes/13-plotting-to-take-over-the-world.md
+++ b/_episodes/13-plotting-to-take-over-the-world.md
@@ -14,12 +14,11 @@ keypoints:
 
 # On Your Own
 
-So in order to make plots, we just need to take the skimmed file `skim_ggH.root` and pass it through the `histograms.py` code that exists. This can be run with the following code
+So, in order to make plots, we just need to take the skimmed file `skim_ggH.root` and pass it through the `histograms.py` code that exists. This can be run with the following code.
 
 ```bash
 python histograms.py skim_ggH.root ggH hist_ggH.root
 ```
-
 
 This needs to be added to your `.gitlab-ci.yml` which should look like the following:
 
@@ -71,9 +70,9 @@ skim_ggH:
 >
 > So we need to do a few things:
 >
-> 1. add a `plot` stage
-> 2. add a `plot_ggH` job
-> 3. save the output `hist_ggH.root` as an artifact (expires in 1 week)
+> 1. Add a `plot` stage
+> 2. Add a `plot_ggH` job
+> 3. Save the output `hist_ggH.root` as an artifact (expires in 1 week)
 >
 > You know what? While you're at it, why not delete the `greeting` stage and `hello_world` job too? There's no need for it anymore 🙂.
 >
@@ -106,7 +105,7 @@ Once we're done, we should probably start thinking about how to test some of the
 
 > ## Are we testing anything?
 >
-> Integration testing is actually testing that the scripts we have still run. So we are constantly testing as we go here which is nice. Additionally, there's also continuous deployment because we've been making artifacts that are passed to other jobs. There are many ways to deploy the results of the code base, such as pushing to a web server, or putting files on EOS from the CI jobs, and so on. Artifacts are one way to deploy.
+> Integration testing is actually testing that the scripts we have still run. So we are constantly testing as we go here, which is nice. Additionally, there's also continuous deployment because we've been making artifacts that are passed to other jobs. There are many ways to deploy the results of the code base, such as pushing to a web server, putting files on EOS from the CI jobs, and so on. Artifacts are one way to deploy.
 {: .callout}
 
 

--- a/_episodes/13-plotting-to-take-over-the-world.md
+++ b/_episodes/13-plotting-to-take-over-the-world.md
@@ -50,7 +50,7 @@ multi_build:
   image: $ROOT_IMAGE
   parallel:
     matrix:
-      - ROOT_IMAGE: ["rootproject/root:6.28.10-ubuntu22.04","rootproject/root:latest"]
+      - ROOT_IMAGE: ["rootproject/root:6.28.10-ubuntu22.04", "rootproject/root:latest"]
 
 skim_ggH:
   stage: run

--- a/_episodes/14-a-simple-test.md
+++ b/_episodes/14-a-simple-test.md
@@ -3,7 +3,7 @@ title: "Let's Actually Make A Test (For Real)"
 teaching: 5
 exercises: 20
 objectives:
-  - Actually add a test on the output of running physics
+  - Actually add a test on the output of running physics.
 questions:
   - I'm out of questions.
   - I've been here too long. Mr. Stark, I don't feel too good.
@@ -14,7 +14,7 @@ keypoints:
 ---
 <iframe width="560" height="315" src="https://www.youtube.com/embed/skHqk7pA2cY?si=_wJCZTm6DdzJm62I" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
-So at this point, I'm going to be very hands-off, and just explain what you will be doing. Here's where you should be starting from:
+So at this point, I'm going to be very hands-off and just explain what you will be doing. Here's where you should be starting from:
 
 ~~~yml
 stages:
@@ -71,21 +71,21 @@ plot_ggH:
 > ## Adding a regression test
 >
 > 1. Add a `test` stage after the `plot` stage.
-> 2. Add a test job, `test_ggH`, part of the `test` stage, and has the right `dependencies`
->   - Note: `./skim` needs to be updated to produce a `skim_ggH.log` (hint: `./skim .... > skim_ggH.log`)
->   - We also need the `hist_ggH.root` file produced by the plot job
-> 3. Create a directory called `tests/` and make two python files in it named `test_cutflow_ggH.py` and `test_plot_ggH.py` that uses `PyROOT` and `python3`
->   - you might find the following lines (below) helpful to set up the tests
-> 4. Write a few different tests of your choosing that tests (and asserts) something about `hist_ggH.root`. Some ideas are:
->   - check the structure (does `ggH_pt_1` exist?)
->   - check that the integral of a histogram matches a value you expect
->   - check that the bins of a histogram matches the values you expect
-> 5. Update your `test_ggH` job to execute the regression tests
-> 6. Try causing your CI/CD to fail on the `test_ggH` job
+> 2. Add a test job, `test_ggH`, part of the `test` stage, and has the right `dependencies`.
+>   - Note: `./skim` needs to be updated to produce a `skim_ggH.log` (hint: `./skim .... > skim_ggH.log`).
+>   - We also need the `hist_ggH.root` file produced by the plot job.
+> 3. Create a directory called `tests/` and make two Python files in it named `test_cutflow_ggH.py` and `test_plot_ggH.py` that use `PyROOT` and `python3`.
+>   - You might find the following lines (below) helpful to set up the tests.
+> 4. Write a few different tests of your choosing that test (and assert) something about `hist_ggH.root`. Some ideas are:
+>   - Check the structure (does `ggH_pt_1` exist?).
+>   - Check that the integral of a histogram matches a value you expect.
+>   - Check that the bins of a histogram match the values you expect.
+> 5. Update your `test_ggH` job to execute the regression tests.
+> 6. Try causing your CI/CD to fail on the `test_ggH` job.
 >
 > > ## Done?
 > >
-> > Once you're happy with setting up the regression test, mark your merge request as ready by clicking the `Resolve WIP Status` button, and then merge it in to master.
+> > Once you're happy with setting up the regression test, mark your merge request as ready by clicking the `Resolve WIP Status` button, and then merge it into master.
 > {: .solution}
 {: .challenge}
 

--- a/_episodes/14-a-simple-test.md
+++ b/_episodes/14-a-simple-test.md
@@ -39,7 +39,7 @@ multi_build:
   image: $ROOT_IMAGE
   parallel:
     matrix:
-      - ROOT_IMAGE: ["rootproject/root:6.28.10-ubuntu22.04","rootproject/root:latest"]
+      - ROOT_IMAGE: ["rootproject/root:6.28.10-ubuntu22.04", "rootproject/root:latest"]
 
 skim_ggH:
   stage: run

--- a/_episodes/15-homework.md
+++ b/_episodes/15-homework.md
@@ -37,7 +37,7 @@ multi_build:
   image: $ROOT_IMAGE
   parallel:
     matrix:
-      - ROOT_IMAGE: ["rootproject/root:6.28.10-ubuntu22.04","rootproject/root:latest"]
+      - ROOT_IMAGE: ["rootproject/root:6.28.10-ubuntu22.04", "rootproject/root:latest"]
 
 skim_ggH:
   stage: run

--- a/_episodes/15-homework.md
+++ b/_episodes/15-homework.md
@@ -4,8 +4,6 @@ teaching: 0
 exercises: 30
 objectives:
   - Add more testing, perhaps to statistics.
-questions:
-  - If you have any, ask on Mattermost!
 hidden: false
 keypoints:
   - Use everything you've learned to write your own CI/CD!

--- a/_episodes/15-homework.md
+++ b/_episodes/15-homework.md
@@ -5,7 +5,7 @@ exercises: 30
 objectives:
   - Add more testing, perhaps to statistics.
 questions:
-  - If you have any, ask on mattermost!
+  - If you have any, ask on Mattermost!
 hidden: false
 keypoints:
   - Use everything you've learned to write your own CI/CD!
@@ -78,7 +78,7 @@ test_ggH:
 
 In your `virtual-pipelines-eventselection` repository, you need to:
 
-1. Add more tests for physics
+1. Add more tests for physics.
 2. Go wild!
 
 {% include links.md %}

--- a/index.md
+++ b/index.md
@@ -8,16 +8,6 @@ permalink: index.html  # Is the only page that doesn't follow the pattern /:path
 GitLab is a git platform used for code hosting and collaboration. It can be used to automatically run checks and other code or workflows on GitLab’s servers. 
 The aim of this module is to introduce CI/CD workflows and how to use them to ensure code is robust, reproducible, and preserved.
 
-> ## The skills we'll focus on:
->
-> 1.  Making scripts exit correctly
-> 2.  Building a CI/CD workflow of unlimited potential
-> 3.  Understanding how job runners work (and get access to your clones)
-> 4.  The GitLab permissions model
-> 5.  Protecting secret information while allowing jobs to run
-{: .checklist}
-
-
 > ## Prerequisites
 >
 > This assumes that you'll have some basic background with your command line, for example:
@@ -26,6 +16,18 @@ The aim of this module is to introduce CI/CD workflows and how to use them to en
 > 2. How to run Python scripts (if you are not familiar with Python, click [here](https://swcarpentry.github.io/python-novice-inflammation/))
 > 3. How to interact with remotes in git (if you are not familiar with git, click [here](https://swcarpentry.github.io/git-novice/))
 {: .prereq}
+
+> ## Learning Objectives
+>
+> After completing this module, participants will be able to:
+>
+> - Understand the core concepts of continuous integration and continuous deployment (CI/CD). 
+> - Explain how scripts and exit codes control execution in automated workflows.
+> - Design and implement flexible and extendable CI/CD pipelines using GitLab.  
+> - Understand how CI runners operate and interact with repository code.  
+> - Apply best practices for building reusable and reproducible CI/CD pipelines.  
+> - Manage GitLab permissions and securely handle sensitive information. 
+{: .objectives}
 
 {% include curriculum.html %}
 

--- a/index.md
+++ b/index.md
@@ -5,7 +5,8 @@ permalink: index.html  # Is the only page that doesn't follow the pattern /:path
 ---
 {% include gh_variables.html %}
 
-GitLab is a git platform used for code hosting and collaboration. It can be used to automatically run checks and other code or workflows on GitLab’s servers. We’ll learn how to use this to make our code robust to errors, preserved, and reproducible.
+GitLab is a git platform used for code hosting and collaboration. It can be used to automatically run checks and other code or workflows on GitLab’s servers. 
+The aim of this module is to introduce CI/CD workflows and how they ensure code is robust, reproducible, and preserved.
 
 > ## The skills we'll focus on:
 >

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ permalink: index.html  # Is the only page that doesn't follow the pattern /:path
 {% include gh_variables.html %}
 
 GitLab is a git platform used for code hosting and collaboration. It can be used to automatically run checks and other code or workflows on GitLab’s servers. 
-The aim of this module is to introduce CI/CD workflows and how they ensure code is robust, reproducible, and preserved.
+The aim of this module is to introduce CI/CD workflows and how to use them to ensure code is robust, reproducible, and preserved.
 
 > ## The skills we'll focus on:
 >

--- a/index.md
+++ b/index.md
@@ -22,7 +22,7 @@ GitLab is a git platform used for code hosting and collaboration. It can be used
 > This assumes that you'll have some basic background with your command line, for example:
 >
 > 1. How to execute custom shell scripts (if you are not familiar with the shell, click [here](https://swcarpentry.github.io/shell-novice/))
-> 2. How to run python scripts (if you are not familiar with python, click [here](https://swcarpentry.github.io/python-novice-inflammation/))
+> 2. How to run Python scripts (if you are not familiar with Python, click [here](https://swcarpentry.github.io/python-novice-inflammation/))
 > 3. How to interact with remotes in git (if you are not familiar with git, click [here](https://swcarpentry.github.io/git-novice/))
 {: .prereq}
 

--- a/setup.md
+++ b/setup.md
@@ -26,7 +26,7 @@ instance.
 
 ## Creating a New Project
 
-Following the [setup for the payload](https://hsf-training.github.io/hsf-training-cms-analysis-webpage/setup.html) to download a tarball of the files needed, you'll want to create new projects (e.g. [at CERNs](https://gitlab.cern.ch/projects/new)) on your personal gitlab account called `virtual-pipelines-eventselection`. Please make sure to set the visibility level to **Public**.
+Following the [setup for the payload](https://hsf-training.github.io/hsf-training-cms-analysis-webpage/setup.html) to download a tarball of the files needed, you'll want to create new projects (e.g. [at CERNs](https://gitlab.cern.ch/projects/new)) on your personal GitLab account called `virtual-pipelines-eventselection`. Please make sure to set the visibility level to **Public**.
 
 If you have not set this payload up yet, you can clone it from [github](https://github.com/hsf-training/hsf-training-cms-analysis) and push it to your project.
 

--- a/setup.md
+++ b/setup.md
@@ -39,10 +39,3 @@ git push -u origin main
 
 
 Alternatively, you could follow the [setup for the payload](https://hsf-training.github.io/hsf-training-cms-analysis-webpage/setup.html) to download a tarball of the repository files and push them to yours.
-
-> ## Visibility Level
->
-> Make sure you click Public for the visibility level of the new project so that everyone can see your awesome work
-> (and it will also make things easier when we get to working with containers).
-> ![example of a properly-filled-in blank project form for gitlab]({{site.baseurl}}/fig/blank-project-form.png)
-{: .callout}

--- a/setup.md
+++ b/setup.md
@@ -6,9 +6,6 @@ questions:
 ---
 > ## Prerequisites
 >
-> Most of the prerequisites should have been covered if you did the
-> pre-workshop material.
->
 > At a bare minimum:
 > - You should have git working on your laptop
 > - We assume that you already have a CERN account or access to a GitLab instance
@@ -17,10 +14,6 @@ questions:
 
 You should find your way to your very own GitLab homepage!
 For CERN this is [gitlab.cern.ch](https://gitlab.cern.ch).
-
-If you're having issues, **please let us know immediately**
-since you won't be able to follow this lesson without access to a GitLab
-instance.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/Pz1gtlQDVyo?si=LcG6YVteCQ38SZ12" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 

--- a/setup.md
+++ b/setup.md
@@ -19,9 +19,26 @@ For CERN this is [gitlab.cern.ch](https://gitlab.cern.ch).
 
 ## Creating a New Project
 
-Following the [setup for the payload](https://hsf-training.github.io/hsf-training-cms-analysis-webpage/setup.html) to download a tarball of the files needed, you'll want to create new projects (e.g. [at CERNs](https://gitlab.cern.ch/projects/new)) on your personal GitLab account called `virtual-pipelines-eventselection`. Please make sure to set the visibility level to **Public**.
+Create a new project (e.g. [at CERNs](https://gitlab.cern.ch/projects/new)) on your personal GitLab account called `virtual-pipelines-eventselection`. Please make sure to set the visibility level to **Public**, and to create the repository **without** the default `README`, as shown below.
 
-If you have not set this payload up yet, you can clone it from [github](https://github.com/hsf-training/hsf-training-cms-analysis) and push it to your project.
+> ## Visibility Level
+>
+> Make sure you click Public for the visibility level of the new project so that everyone can see your awesome work
+> (and it will also make things easier when we get to working with containers).
+> ![example of a properly-filled-in blank project form for gitlab]({{site.baseurl}}/fig/blank-project-form.png)
+{: .callout}
+
+We will now copy an existing repository to this project
+~~~bash
+git init virtual-pipelines-eventselection
+cd virtual-pipelines-eventselection
+git pull https://github.com/hsf-training/hsf-training-cms-analysis
+git remote add origin <clone-url (ssh or https) of the project you just created>
+git push -u origin main
+~~~
+
+
+Alternatively, you could follow the [setup for the payload](https://hsf-training.github.io/hsf-training-cms-analysis-webpage/setup.html) to download a tarball of the repository files and push them to yours.
 
 > ## Visibility Level
 >


### PR DESCRIPTION
## Changes
- removed references to the original workshop from which this lesson was built from.
- remove past events section in REAME (it was not up to date).
- rewrite CI/CD definition.
- replace `:(){ return 1; };:` with `false`.


## Additions
- add learning objectives.
- motivate exit codes.
- explain significance of other exit codes.
- explain using `true` in `false` in place of `echo <message>` to silently override exit codes.
- explain stages in more depth.
- explain short-circuit boolean evaluation.
- update repository creation guide.
- add Zenodo info to README.


And some other small updates to grammar, formatting, and README + index.md.
